### PR TITLE
Add screenshot to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple web app for tracking meat smoking performance. Enter in a start time and temperature, and track the internal temperature of your preferred meat during the smoking process.
 
+![App Screenshot](https://mattschroyer.github.io/img/buddy_cue_screenshot.png)
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts


### PR DESCRIPTION
Adds screenshot for the Buddy Cue app to the Readme.

Currently this is linked to the screenshot image used in github pages -- should maybe later move this into the codebase itself?