### PR TITLE
refactor: formatted time

### DIFF
--- a/src/components/LaunchModal/InitEntryContent.tsx
+++ b/src/components/LaunchModal/InitEntryContent.tsx
@@ -80,19 +80,16 @@ const InitEntryContent: React.FC<InitEntryContentType> = ({ onSubmit }) => {
       ? temp - timeTemp[timeTemp.length - 1].temp
       : 0;
 
-    const formattedTime = time
-      .toLocaleTimeString()
-      .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3");
+    const newTimeTemp = {
+      timeIndex,
+      temp,
+      time: time.toISOString(),
+      tempDiff,
+      addedCoals: true,
+    };
     
     dispatch(
-      addTimeTemp({
-        timeIndex,
-        temp,
-        time,
-        formattedTime,
-        tempDiff,
-        addedCoals: true,
-      })
+      addTimeTemp(newTimeTemp)
     );
 
     dispatch(

--- a/src/components/Main/TimeTempChart.tsx
+++ b/src/components/Main/TimeTempChart.tsx
@@ -10,15 +10,18 @@ import {
 } from "recharts";
 import { useSelector } from "react-redux";
 import { RootState } from "../../redux/store";
+import { getFormattedTimeTemp } from "../../utils";
 
 const TimeTempChart: React.FC = () => {
   const timeTemp = useSelector((state: RootState) => state.session.timeTemp);
+
+  const formattedTimeTemp = getFormattedTimeTemp(timeTemp);
 
   return (
     <LineChart
       width={500}
       height={300}
-      data={timeTemp}
+      data={formattedTimeTemp}
       margin={{
         top: 5,
         right: 30,

--- a/src/components/Main/TimeTempEntry.tsx
+++ b/src/components/Main/TimeTempEntry.tsx
@@ -56,19 +56,16 @@ const TimeTempEntry: React.FC = () => {
       ? temp - timeTemp[timeTemp.length - 1].temp
       : 0;
 
-    const formattedTime = nextTime
-      .toLocaleTimeString()
-      .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3");
+    const newTimeTemp = {
+      timeIndex: nextTimeIndex,
+      temp,
+      time: nextTime.toISOString(),
+      tempDiff,
+      addedCoals: !!coals,
+    };
 
     dispatch(
-      addTimeTemp({
-        timeIndex: nextTimeIndex,
-        temp,
-        time: nextTime,
-        formattedTime,
-        tempDiff,
-        addedCoals: !!coals,
-      })
+      addTimeTemp(newTimeTemp)
     );
   };
 

--- a/src/components/Main/TimeTempTable.tsx
+++ b/src/components/Main/TimeTempTable.tsx
@@ -14,6 +14,7 @@ const TimeTempTable: React.FC = () => {
 
   const timeTemp = useSelector((state: RootState) => state.session.timeTemp);
 
+  // TODO: Row can be own component
   const TempRows =
     timeTemp &&
     timeTemp.map((thisTimeTemp) => {

--- a/src/components/Main/TimeTempTable.tsx
+++ b/src/components/Main/TimeTempTable.tsx
@@ -8,6 +8,7 @@ import {
 } from "@mui/material";
 import { useSelector } from "react-redux";
 import { RootState } from "../../redux/store";
+import { getFormattedTime } from "../../utils";
 
 const TimeTempTable: React.FC = () => {
 
@@ -16,8 +17,11 @@ const TimeTempTable: React.FC = () => {
   const TempRows =
     timeTemp &&
     timeTemp.map((thisTimeTemp) => {
-      const { timeIndex, formattedTime, temp, tempDiff, addedCoals } =
+      const { timeIndex, time, temp, tempDiff, addedCoals } =
         thisTimeTemp;
+
+      const formattedTime = getFormattedTime(time);
+
       return (
         <TableRow key={timeIndex}>
           <TableCell>{formattedTime}</TableCell>

--- a/src/redux/slices/sessionSlice.ts
+++ b/src/redux/slices/sessionSlice.ts
@@ -4,8 +4,7 @@ import { GOAL_INT_TEMP, HOURS_PER_LB } from '../../constants';
 
 export type TimeTempType = {
   timeIndex: number;
-  time: Date;
-  formattedTime: string;
+  time: string;
   temp: number;
   tempDiff: number;
   addedCoals: boolean;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,3 +29,23 @@ export const isTempWarning = (
 
   return avgTempInc < reqAvgTempInc;
 };
+
+export const getFormattedTime = (time: string) => {
+  return new Date(time)
+    .toLocaleTimeString()
+    .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3");
+};
+
+export const getFormattedTimeTemp = (timeTemp: TimeTempType[]) => {
+  const formattedTimeTemp = timeTemp.map((el) => {
+    const{ time } = el;
+    const formattedTime = getFormattedTime(time);
+    
+    return {
+      ...el,
+      formattedTime,
+    };
+  });
+
+  return formattedTimeTemp;
+};


### PR DESCRIPTION
Previously, the time in each entry of the session would be stored in state, along with  a formatted time string.

This was unnecessary; it's better to have just a single time per entry, and format it in-situ as the needs of the component dictates.

PR refactors the state and components to work off a single time in the entry, and also exports some of these re-used patterns as utilities.

Also adds a `todo` about each row in the table being its own component.