### PR TITLE
refactor: calculate temp delta in situ

### DIFF
--- a/src/components/LaunchModal/InitEntryContent.tsx
+++ b/src/components/LaunchModal/InitEntryContent.tsx
@@ -76,15 +76,10 @@ const InitEntryContent: React.FC<InitEntryContentType> = ({ onSubmit }) => {
   };
 
   const onTempButtonClick = () => {
-    const tempDiff = timeTemp.length
-      ? temp - timeTemp[timeTemp.length - 1].temp
-      : 0;
-
     const newTimeTemp = {
       timeIndex,
       temp,
       time: time.toISOString(),
-      tempDiff,
       addedCoals: true,
     };
     

--- a/src/components/Main/TimeTempEntry.tsx
+++ b/src/components/Main/TimeTempEntry.tsx
@@ -51,16 +51,10 @@ const TimeTempEntry: React.FC = () => {
   };
 
   const onTempButtonClick = () => {
-    // todo: temp delta should be calculated in situ, not part of state or record
-    const tempDiff = timeTemp.length
-      ? temp - timeTemp[timeTemp.length - 1].temp
-      : 0;
-
     const newTimeTemp = {
       timeIndex: nextTimeIndex,
       temp,
       time: nextTime.toISOString(),
-      tempDiff,
       addedCoals: !!coals,
     };
 

--- a/src/components/Main/TimeTempTable.tsx
+++ b/src/components/Main/TimeTempTable.tsx
@@ -17,11 +17,15 @@ const TimeTempTable: React.FC = () => {
   // TODO: Row can be own component
   const TempRows =
     timeTemp &&
-    timeTemp.map((thisTimeTemp) => {
-      const { timeIndex, time, temp, tempDiff, addedCoals } =
+    timeTemp.map((thisTimeTemp, i) => {
+      const { timeIndex, time, temp, addedCoals } =
         thisTimeTemp;
 
       const formattedTime = getFormattedTime(time);
+
+      const tempDiff = i
+        ? temp - timeTemp[i - 1].temp
+        : 0;
 
       return (
         <TableRow key={timeIndex}>

--- a/src/redux/slices/sessionSlice.ts
+++ b/src/redux/slices/sessionSlice.ts
@@ -2,11 +2,11 @@ import { createSlice } from '@reduxjs/toolkit';
 import { isTempWarning } from '../../utils';
 import { GOAL_INT_TEMP, HOURS_PER_LB } from '../../constants';
 
+// TODO: remove unnecessary timeIndex
 export type TimeTempType = {
   timeIndex: number;
   time: string;
   temp: number;
-  tempDiff: number;
   addedCoals: boolean;
 };
 


### PR DESCRIPTION
The temp delta (`tempDiff`) was being kept in state, when it should only be calculated in-situ. This not only cleans up the state, but also aligns the state better with what we expect to get from the backend in terms of the session state.