### PR TITLE
Refactor: Time and date handling

### DIFF
--- a/src/components/LaunchModal/InitEntryContent.tsx
+++ b/src/components/LaunchModal/InitEntryContent.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { TextField, Button } from "@mui/material";
 import styled from "@emotion/styled";
 import TimeSelect from "./TimeSelect";
 import { addTimeTemp, setWeight } from "../../redux/slices/sessionSlice";
-import { RootState } from "../../redux/store";
 
 const InitEntryContentContainer = styled.div`
   position: absolute;
@@ -51,19 +50,16 @@ export type InitEntryContentType = {
 };
 
 const InitEntryContent: React.FC<InitEntryContentType> = ({ onSubmit }) => {
-  const timeTemp = useSelector((state: RootState) => state.session.timeTemp);
-
   const startDate = new Date();
   startDate.setHours(6, 0, 0, 0);
-  const [timeIndex, setTimeIndex] = useState<number>(0);
   const [time, setTime] = useState<Date>(startDate);
   const [temp, setTemp] = useState<number>(0);
   const [thisWeight, setThisWeight] = useState<number>(0);
 
   const dispatch = useDispatch();
 
-  const onTimeInputChange = (index: number, thisTime: Date) => {
-    setTimeIndex(index);
+  const onTimeInputChange = (dateString: string) => {
+    const thisTime = new Date(dateString);
     setTime(thisTime);
   };
 
@@ -77,7 +73,6 @@ const InitEntryContent: React.FC<InitEntryContentType> = ({ onSubmit }) => {
 
   const onTempButtonClick = () => {
     const newTimeTemp = {
-      timeIndex,
       temp,
       time: time.toISOString(),
       addedCoals: true,

--- a/src/components/LaunchModal/InitEntryContent.tsx
+++ b/src/components/LaunchModal/InitEntryContent.tsx
@@ -4,6 +4,7 @@ import { TextField, Button } from "@mui/material";
 import styled from "@emotion/styled";
 import TimeSelect from "./TimeSelect";
 import { addTimeTemp, setWeight } from "../../redux/slices/sessionSlice";
+import { getDefaultStartTime } from "../../utils";
 
 const InitEntryContentContainer = styled.div`
   position: absolute;
@@ -50,16 +51,15 @@ export type InitEntryContentType = {
 };
 
 const InitEntryContent: React.FC<InitEntryContentType> = ({ onSubmit }) => {
-  const startDate = new Date();
-  startDate.setHours(6, 0, 0, 0);
-  const [time, setTime] = useState<Date>(startDate);
+  const startTime = getDefaultStartTime();
+
+  const [time, setTime] = useState<string>(startTime);
   const [temp, setTemp] = useState<number>(0);
   const [thisWeight, setThisWeight] = useState<number>(0);
 
   const dispatch = useDispatch();
 
-  const onTimeInputChange = (dateString: string) => {
-    const thisTime = new Date(dateString);
+  const onTimeInputChange = (thisTime: string) => {
     setTime(thisTime);
   };
 
@@ -74,7 +74,7 @@ const InitEntryContent: React.FC<InitEntryContentType> = ({ onSubmit }) => {
   const onTempButtonClick = () => {
     const newTimeTemp = {
       temp,
-      time: time.toISOString(),
+      time,
       addedCoals: true,
     };
     

--- a/src/components/LaunchModal/TimeSelect.tsx
+++ b/src/components/LaunchModal/TimeSelect.tsx
@@ -16,11 +16,11 @@ const TimeSelect: React.FC<TimeSelectType> = ({ onChange }) => {
   const firstStartTime = startTimes[0].toString();
   const [thisTimeString, setThisTimeString] = useState<string | undefined>(firstStartTime);
 
-  const MenuItems = startTimes.map((thisDateArr) => {
-    const dateString = thisDateArr.toString();
+  const MenuItems = startTimes.map((date) => {
+    const dateString = date.toString();
     return (
       <MenuItem key={dateString} value={dateString}>
-        {thisDateArr
+        {date
           .toLocaleTimeString()
           .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3")}
       </MenuItem>

--- a/src/components/LaunchModal/TimeSelect.tsx
+++ b/src/components/LaunchModal/TimeSelect.tsx
@@ -4,20 +4,22 @@ import { getStartTimes } from "../../utils";
 
 export type OnDateChangeType = React.ChangeEvent<{
   name?: string | undefined;
-  value: unknown;
+  value: string;
 }>;
 
 export type TimeSelectType = {
-  onChange: (i: number, d: Date) => void;
+  onChange: (dateString: string) => void;
 };
 
 const TimeSelect: React.FC<TimeSelectType> = ({ onChange }) => {
   const startTimes = getStartTimes();
-  const [thisTimeIndex, setThisTimeIndex] = useState(0);
+  const firstStartTime = startTimes[0].toString();
+  const [thisTimeString, setThisTimeString] = useState<string | undefined>(firstStartTime);
 
-  const MenuItems = startTimes.map((thisDateArr, i) => {
+  const MenuItems = startTimes.map((thisDateArr) => {
+    const dateString = thisDateArr.toString();
     return (
-      <MenuItem key={thisDateArr.toString()} value={i}>
+      <MenuItem key={dateString} value={dateString}>
         {thisDateArr
           .toLocaleTimeString()
           .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3")}
@@ -26,10 +28,9 @@ const TimeSelect: React.FC<TimeSelectType> = ({ onChange }) => {
   });
 
   const onTimeChange = (e: OnDateChangeType) => {
-    const thisIndex = e.target.value as number;
-    const thisDate = startTimes[thisIndex];
-    onChange(thisIndex, thisDate);
-    setThisTimeIndex(thisIndex);
+    const thisDateString = e.target.value;
+    onChange(thisDateString);
+    setThisTimeString(thisDateString);
   };
 
   return (
@@ -37,7 +38,7 @@ const TimeSelect: React.FC<TimeSelectType> = ({ onChange }) => {
       labelId="demo-simple-select-label"
       id="demo-simple-select"
       onChange={(e) => onTimeChange(e)}
-      value={thisTimeIndex}
+      value={thisTimeString}
     >
       {MenuItems}
     </Select>

--- a/src/components/LaunchModal/TimeSelect.tsx
+++ b/src/components/LaunchModal/TimeSelect.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Select, MenuItem } from "@mui/material";
-import { getStartTimes } from "../../utils";
+import { getFormattedTime, getTimeIntervals } from "../../utils";
 
 export type OnDateChangeType = React.ChangeEvent<{
   name?: string | undefined;
@@ -12,17 +12,15 @@ export type TimeSelectType = {
 };
 
 const TimeSelect: React.FC<TimeSelectType> = ({ onChange }) => {
-  const startTimes = getStartTimes();
+  const startTimes = getTimeIntervals();
   const firstStartTime = startTimes[0].toString();
   const [thisTimeString, setThisTimeString] = useState<string | undefined>(firstStartTime);
 
-  const MenuItems = startTimes.map((date) => {
-    const dateString = date.toString();
+  const MenuItems = startTimes.map((dateString: string) => {
+    const formattedTime = getFormattedTime(dateString);
     return (
       <MenuItem key={dateString} value={dateString}>
-        {date
-          .toLocaleTimeString()
-          .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3")}
+        {formattedTime}
       </MenuItem>
     );
   });

--- a/src/components/LaunchModal/TimeSelect.tsx
+++ b/src/components/LaunchModal/TimeSelect.tsx
@@ -13,8 +13,7 @@ export type TimeSelectType = {
 
 const TimeSelect: React.FC<TimeSelectType> = ({ onChange }) => {
   const startTimes = getTimeIntervals();
-  const firstStartTime = startTimes[0].toString();
-  const [thisTimeString, setThisTimeString] = useState<string | undefined>(firstStartTime);
+  const [thisTimeString, setThisTimeString] = useState<string | undefined>(startTimes[0]);
 
   const MenuItems = startTimes.map((dateString: string) => {
     const formattedTime = getFormattedTime(dateString);

--- a/src/components/Main/TimeTempEntry.tsx
+++ b/src/components/Main/TimeTempEntry.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { Button, MenuItem, Select, TextField } from "@mui/material";
 import { addTimeTemp } from "../../redux/slices/sessionSlice";
 import { RootState } from "../../redux/store";
-import { getFormattedTime, getTimeIntervals } from "../../utils";
+import { getDefaultStartDate, getFormattedTime, getTimeIntervals } from "../../utils";
 
 export type OnCoalsChangeType = React.ChangeEvent<{
   name?: string | undefined;
@@ -31,8 +31,6 @@ const TimeTempEntry: React.FC = () => {
   const timeArr = getTimeIntervals();
   const timeTemp = useSelector((state: RootState) => state.session.timeTemp);
 
-  const startDate = new Date();
-  startDate.setHours(6, 0, 0, 0);
   const [temp, setTemp] = useState<number>(0);
   const [coals, setCoals] = useState<number>(0);
 

--- a/src/components/Main/TimeTempEntry.tsx
+++ b/src/components/Main/TimeTempEntry.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { Button, MenuItem, Select, TextField } from "@mui/material";
 import { addTimeTemp } from "../../redux/slices/sessionSlice";
 import { RootState } from "../../redux/store";
-import { getStartTimes } from "../../utils";
+import { getTimeIntervals } from "../../utils";
 
 export type OnCoalsChangeType = React.ChangeEvent<{
   name?: string | undefined;
@@ -28,7 +28,7 @@ export type OnTimeInputChangeType = {
 };
 
 const TimeTempEntry: React.FC = () => {
-  const dateArr = getStartTimes();
+  const timeArr = getTimeIntervals();
   const timeTemp = useSelector((state: RootState) => state.session.timeTemp);
 
   const startDate = new Date();
@@ -38,7 +38,7 @@ const TimeTempEntry: React.FC = () => {
 
   const dispatch = useDispatch();
 
-  const prevTime = new Date(timeTemp.at(-1)?.time || dateArr[0]);
+  const prevTime = new Date(timeTemp.at(-1)?.time || timeArr[0]);
 
   // TODO: No magic numbers
   const nextTime = new Date(prevTime.getTime() + (30 * 60 * 1000));

--- a/src/components/Main/TimeTempEntry.tsx
+++ b/src/components/Main/TimeTempEntry.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { Button, MenuItem, Select, TextField } from "@mui/material";
 import { addTimeTemp } from "../../redux/slices/sessionSlice";
 import { RootState } from "../../redux/store";
-import { getTimeIntervals } from "../../utils";
+import { getFormattedTime, getTimeIntervals } from "../../utils";
 
 export type OnCoalsChangeType = React.ChangeEvent<{
   name?: string | undefined;
@@ -41,10 +41,8 @@ const TimeTempEntry: React.FC = () => {
   const prevTime = new Date(timeTemp.at(-1)?.time || timeArr[0]);
 
   // TODO: No magic numbers
-  const nextTime = new Date(prevTime.getTime() + (30 * 60 * 1000));
-  const nextTimeString = nextTime
-    .toLocaleTimeString()
-    .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3");
+  const newTime = new Date(prevTime.getTime() + (30 * 60 * 1000)).toISOString();
+  const newTimeFormatted = getFormattedTime(newTime);
 
   const onTempInputChange = (e: OnChangeEventType) => {
     setTemp(parseInt(e.target.value, 10));
@@ -53,7 +51,7 @@ const TimeTempEntry: React.FC = () => {
   const onTempButtonClick = () => {
     const newTimeTemp = {
       temp,
-      time: nextTime.toISOString(),
+      time: newTime,
       addedCoals: !!coals,
     };
 
@@ -68,7 +66,7 @@ const TimeTempEntry: React.FC = () => {
 
   return (
     <TimeTempEntryContent>
-      <div style={{ padding: "12px" }}>{nextTimeString}</div>
+      <div style={{ padding: "12px" }}>{newTimeFormatted}</div>
       <div style={{ padding: "12px" }}>
         <TextField
           id="temp-input"

--- a/src/components/Main/TimeTempEntry.tsx
+++ b/src/components/Main/TimeTempEntry.tsx
@@ -38,10 +38,10 @@ const TimeTempEntry: React.FC = () => {
 
   const dispatch = useDispatch();
 
-  const nextTimeIndex = timeTemp.length
-    ? timeTemp[timeTemp.length - 1].timeIndex + 1
-    : 0;
-  const nextTime = dateArr[nextTimeIndex];
+  const prevTime = new Date(timeTemp.at(-1)?.time || dateArr[0]);
+
+  // TODO: No magic numbers
+  const nextTime = new Date(prevTime.getTime() + (30 * 60 * 1000));
   const nextTimeString = nextTime
     .toLocaleTimeString()
     .replace(/([\d]+:[\d]{2})(:[\d]{2})(.*)/, "$1$3");
@@ -52,7 +52,6 @@ const TimeTempEntry: React.FC = () => {
 
   const onTempButtonClick = () => {
     const newTimeTemp = {
-      timeIndex: nextTimeIndex,
       temp,
       time: nextTime.toISOString(),
       addedCoals: !!coals,

--- a/src/components/Main/TimeTempTable.tsx
+++ b/src/components/Main/TimeTempTable.tsx
@@ -18,7 +18,7 @@ const TimeTempTable: React.FC = () => {
   const TempRows =
     timeTemp &&
     timeTemp.map((thisTimeTemp, i) => {
-      const { timeIndex, time, temp, addedCoals } =
+      const { time, temp, addedCoals } =
         thisTimeTemp;
 
       const formattedTime = getFormattedTime(time);
@@ -28,7 +28,7 @@ const TimeTempTable: React.FC = () => {
         : 0;
 
       return (
-        <TableRow key={timeIndex}>
+        <TableRow key={time}>
           <TableCell>{formattedTime}</TableCell>
           <TableCell>{`${temp}\xB0F`}</TableCell>
           <TableCell>{tempDiff}</TableCell>

--- a/src/redux/slices/sessionSlice.ts
+++ b/src/redux/slices/sessionSlice.ts
@@ -2,9 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import { isTempWarning } from '../../utils';
 import { GOAL_INT_TEMP, HOURS_PER_LB } from '../../constants';
 
-// TODO: remove unnecessary timeIndex
 export type TimeTempType = {
-  timeIndex: number;
   time: string;
   temp: number;
   addedCoals: boolean;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,20 @@
 import { TimeTempType } from "../redux/slices/sessionSlice";
 
-export const getTimeIntervals = (): string[] => {
+export const getDefaultStartDate = (): Date => {
   const startDate = new Date();
   startDate.setHours(6, 0, 0, 0);
+
+  return startDate;
+};
+
+export const getDefaultStartTime = (): string => {
+  const defaultStartDate = getDefaultStartDate();
+  
+  return defaultStartDate.toISOString();
+}
+
+export const getTimeIntervals = (): string[] => {
+  const startDate = getDefaultStartDate();
 
   const startTimes = Array.from(Array(29), (x, i) => {
     const thisDate = new Date(startDate);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,13 +1,14 @@
 import { TimeTempType } from "../redux/slices/sessionSlice";
 
-export const getStartTimes = (): Date[] => {
+export const getTimeIntervals = (): string[] => {
   const startDate = new Date();
   startDate.setHours(6, 0, 0, 0);
 
   const startTimes = Array.from(Array(29), (x, i) => {
     const thisDate = new Date(startDate);
     thisDate.setMinutes(startDate.getMinutes() + 30 * i);
-    return thisDate;
+
+    return thisDate.toString();
   });
 
   return startTimes;


### PR DESCRIPTION
* Removes the concept of a "timeIndex," which is unnecessary as arrays already have an index
* Adds utilities to get the default start date and date time (going forward, dates are date objects and time is a date represented as an iso string)

Much of the date and time handling logic will probably be removed eventually as we move to live time entry (time being recorded as the moment you enter a new temperature in the session, not as per-determined 30 minute intervals). But for now, this makes the code more readable and understandable and situates the codebase better for that change.