### PR TITLE
refactor: improved file structure for cleaner imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,7 @@
 import React from "react";
 import { ThemeProvider, createTheme } from '@mui/material/styles';
-import TimeTempEntry from "./components/Main/TimeTempEntry";
-import TimeTempTable from "./components/Main/TimeTempTable";
 import LaunchModal from "./components/LaunchModal/LaunchModal";
-import TimeTempChart from "./components/Main/TimeTempChart";
-import TempWarningModal from "./components/Main/TempWarningModal";
+import Main from "./components/Main";
 
 const theme = createTheme();
 
@@ -12,16 +9,7 @@ const App: React.FC = () => {
   return (
     <ThemeProvider theme={theme}>
       <LaunchModal />
-      <TempWarningModal />
-      <div style={{ padding: "12px" }}>
-        <TimeTempEntry />
-      </div>
-      <div style={{ padding: "12px" }}>
-        <TimeTempChart />
-      </div>
-      <div style={{ padding: "12px" }}>
-        <TimeTempTable />
-      </div>
+      <Main />
     </ThemeProvider>
   );
 };

--- a/src/components/LaunchModal/InitEntryContent/InitEntryContent.tsx
+++ b/src/components/LaunchModal/InitEntryContent/InitEntryContent.tsx
@@ -2,9 +2,9 @@ import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { TextField, Button } from "@mui/material";
 import styled from "@emotion/styled";
-import TimeSelect from "./TimeSelect";
-import { addTimeTemp, setWeight } from "../../redux/slices/sessionSlice";
-import { getDefaultStartTime } from "../../utils";
+import TimeSelect from "../TimeSelect/TimeSelect";
+import { addTimeTemp, setWeight } from "../../../redux/slices/sessionSlice";
+import { getDefaultStartTime } from "../../../utils";
 
 const InitEntryContentContainer = styled.div`
   position: absolute;
@@ -46,11 +46,11 @@ export type OnTimeInputChangeType = {
   name?: string | undefined;
 };
 
-export type InitEntryContentType = {
+export type Props = {
   onSubmit: () => void;
 };
 
-const InitEntryContent: React.FC<InitEntryContentType> = ({ onSubmit }) => {
+const InitEntryContent: React.FC<Props> = ({ onSubmit }) => {
   const startTime = getDefaultStartTime();
 
   const [time, setTime] = useState<string>(startTime);

--- a/src/components/LaunchModal/InitEntryContent/index.ts
+++ b/src/components/LaunchModal/InitEntryContent/index.ts
@@ -1,0 +1,2 @@
+export { default } from './InitEntryContent';
+export type { Props as InitEntryContentProps } from './InitEntryContent';

--- a/src/components/LaunchModal/InitEstContent/InitEstContent.tsx
+++ b/src/components/LaunchModal/InitEstContent/InitEstContent.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { Button } from "@mui/material";
 import styled from "@emotion/styled";
-import { HOURS_PER_LB } from "../../constants";
-import { RootState } from "../../redux/store";
+import { HOURS_PER_LB } from "../../../constants";
+import { RootState } from "../../../redux/store";
 
 const InitEstContentContainer = styled.div`
   position: absolute;
@@ -17,11 +17,11 @@ const InitEstContentContainer = styled.div`
   border-radius: 4px;
 `;
 
-export type InitEntryContentType = {
+export type Props = {
   onClose: () => void;
 };
 
-const InitEstContent: React.FC<InitEntryContentType> = ({ onClose }) => {
+const InitEstContent: React.FC<Props> = ({ onClose }) => {
   const weight = useSelector((state: RootState) => state.session.weight);
   const estTime = weight * HOURS_PER_LB;
 

--- a/src/components/LaunchModal/InitEstContent/index.ts
+++ b/src/components/LaunchModal/InitEstContent/index.ts
@@ -1,0 +1,2 @@
+export { default } from './InitEstContent';
+export type { Props as InitEstContentProps } from './InitEstContent';

--- a/src/components/LaunchModal/LaunchModal.tsx
+++ b/src/components/LaunchModal/LaunchModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Modal } from "@mui/material";
-import InitEntryContent from "./InitEntryContent";
-import InitEstContent from "./InitEstContent";
+import InitEntryContent from "./InitEntryContent/";
+import InitEstContent from "./InitEstContent/";
 
 export type OnChangeEventType = {
   target: {

--- a/src/components/LaunchModal/TimeSelect/TimeSelect.tsx
+++ b/src/components/LaunchModal/TimeSelect/TimeSelect.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from "react";
 import { Select, MenuItem } from "@mui/material";
-import { getFormattedTime, getTimeIntervals } from "../../utils";
+import { getFormattedTime, getTimeIntervals } from "../../../utils";
 
 export type OnDateChangeType = React.ChangeEvent<{
   name?: string | undefined;
   value: string;
 }>;
 
-export type TimeSelectType = {
+export type Props = {
   onChange: (dateString: string) => void;
 };
 
-const TimeSelect: React.FC<TimeSelectType> = ({ onChange }) => {
+const TimeSelect: React.FC<Props> = ({ onChange }) => {
   const startTimes = getTimeIntervals();
   const [thisTimeString, setThisTimeString] = useState<string | undefined>(startTimes[0]);
 

--- a/src/components/LaunchModal/TimeSelect/index.ts
+++ b/src/components/LaunchModal/TimeSelect/index.ts
@@ -1,0 +1,2 @@
+export { default } from './TimeSelect';
+export type { Props as TimeSelectProps } from './TimeSelect';

--- a/src/components/LaunchModal/index.ts
+++ b/src/components/LaunchModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LaunchModal';

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import TempWarningModal from "./TempWarningModal";
+import TimeTempChart from "./TimeTempChart";
+import TimeTempEntry from "./TimeTempEntry";
+import TimeTempTable from "./TimeTempTable";
+
+const Main: React.FC = () => {
+  return (
+    <>
+      <TempWarningModal />
+      <div style={{ padding: "12px" }}>
+        <TimeTempEntry />
+      </div>
+      <div style={{ padding: "12px" }}>
+        <TimeTempChart />
+      </div>
+      <div style={{ padding: "12px" }}>
+        <TimeTempTable />
+      </div>
+    </>
+  );
+};
+
+export default Main;

--- a/src/components/Main/TempWarningModal/TempWarningModal.tsx
+++ b/src/components/Main/TempWarningModal/TempWarningModal.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Modal, Button } from "@mui/material";
 import styled from "@emotion/styled";
 import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "../../redux/store";
-import { setWarning } from "../../redux/slices/sessionSlice";
+import { RootState } from "../../../redux/store";
+import { setWarning } from "../../../redux/slices/sessionSlice";
 
 const TempWarningContent = styled.div`
   position: absolute;

--- a/src/components/Main/TempWarningModal/index.ts
+++ b/src/components/Main/TempWarningModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TempWarningModal';

--- a/src/components/Main/TimeTempChart/TimeTempChart.tsx
+++ b/src/components/Main/TimeTempChart/TimeTempChart.tsx
@@ -9,8 +9,8 @@ import {
   Legend,
 } from "recharts";
 import { useSelector } from "react-redux";
-import { RootState } from "../../redux/store";
-import { getFormattedTimeTemp } from "../../utils";
+import { RootState } from "../../../redux/store";
+import { getFormattedTimeTemp } from "../../../utils";
 
 const TimeTempChart: React.FC = () => {
   const timeTemp = useSelector((state: RootState) => state.session.timeTemp);

--- a/src/components/Main/TimeTempChart/index.ts
+++ b/src/components/Main/TimeTempChart/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TimeTempChart';

--- a/src/components/Main/TimeTempEntry/TimeTempEntry.tsx
+++ b/src/components/Main/TimeTempEntry/TimeTempEntry.tsx
@@ -2,9 +2,9 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "@emotion/styled";
 import { Button, MenuItem, Select, TextField } from "@mui/material";
-import { addTimeTemp } from "../../redux/slices/sessionSlice";
-import { RootState } from "../../redux/store";
-import { getDefaultStartDate, getFormattedTime, getTimeIntervals } from "../../utils";
+import { addTimeTemp } from "../../../redux/slices/sessionSlice";
+import { RootState } from "../../../redux/store";
+import { getDefaultStartDate, getFormattedTime, getTimeIntervals } from "../../../utils";
 
 export type OnCoalsChangeType = React.ChangeEvent<{
   name?: string | undefined;

--- a/src/components/Main/TimeTempEntry/index.ts
+++ b/src/components/Main/TimeTempEntry/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TimeTempEntry';

--- a/src/components/Main/TimeTempTable/TimeTempTable.tsx
+++ b/src/components/Main/TimeTempTable/TimeTempTable.tsx
@@ -7,8 +7,8 @@ import {
   TableRow,
 } from "@mui/material";
 import { useSelector } from "react-redux";
-import { RootState } from "../../redux/store";
-import { getFormattedTime } from "../../utils";
+import { RootState } from "../../../redux/store";
+import { getFormattedTime } from "../../../utils";
 
 const TimeTempTable: React.FC = () => {
 

--- a/src/components/Main/TimeTempTable/index.ts
+++ b/src/components/Main/TimeTempTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TimeTempTable';

--- a/src/components/Main/index.ts
+++ b/src/components/Main/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Main';


### PR DESCRIPTION
Adds folder for each component, along with index file, for cleaner imports of components and prop types.

This adds some overhead, but the structure also makes it neater for adding dedicated test files, storybook files, for each component.

Some discussion on this topic: https://stackoverflow.com/questions/44092341/how-do-index-js-files-work-in-react-component-directories