### PR TITLE
refactor: redux store for better importing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import getStore from './redux/store';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ReduxProvider store={getStore}>
+    <ReduxProvider store={getStore()}>
       <App />
     </ReduxProvider>
   </StrictMode>,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,13 +1,27 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import sessionSlice from './slices/sessionSlice';
 
-const store = configureStore({
-  reducer: {
-    session: sessionSlice,
-  },
+const rootReducer = combineReducers({
+  session: sessionSlice,
 });
 
-export type RootState = ReturnType<typeof store.getState>;
-export type AppDispatch = typeof store.dispatch;
+export function setupStore(preloadedState?: Partial<RootState>) {
+  return configureStore({
+    reducer: rootReducer,
+    preloadedState
+  })
+}
 
-export default store;
+export type RootState = ReturnType<typeof rootReducer>
+export type AppStore = ReturnType<typeof setupStore>
+export type AppDispatch = AppStore['dispatch'];
+
+let store: AppStore;
+
+export default function getStore() {
+  if (!store) {
+    store = setupStore();
+  }
+
+  return store;
+}


### PR DESCRIPTION
A slightly different pattern for getStore, which will enable us to mock stores a little cleaner in testing.