### PR TITLE
chore: Remove redundant escapeKeyDown reason on LaunchModal handleclose

### DIFF
--- a/src/components/LaunchModal/LaunchModal.tsx
+++ b/src/components/LaunchModal/LaunchModal.tsx
@@ -24,14 +24,19 @@ const LaunchModal: React.FC = () => {
     <InitEntryForm onSubmit={() => setShowEst(true)} />
   );
 
-  const handleClose = (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => {
+  const handleClose = (event: {}, reason: 'backdropClick') => {
     if (reason && reason == 'backdropClick') return;
 
     setIsOpen(false);
   };
 
   return (
-    <Modal disableEscapeKeyDown open={isOpen} onClose={handleClose} data-testid={testid('root')}>
+    <Modal
+      disableEscapeKeyDown
+      open={isOpen}
+      onClose={handleClose}
+      data-testid={testid('root')}
+    >
       <div>{Content}</div>
     </Modal>
   );


### PR DESCRIPTION
It was redundant to include escapeKeyDown as a type for the reason prop on LaunchModal's handleClose callback, because the callback is never called on an escapeKeyDown, due to the `disableEscapeKeyDown` prop on the Modal MUI component.