### PR TITLE
chore: remove bad todo in TimeSelect

### DIFF
--- a/src/components/LaunchModal/TimeSelect/TimeSelect.tsx
+++ b/src/components/LaunchModal/TimeSelect/TimeSelect.tsx
@@ -11,7 +11,6 @@ export type Props = {
 const TimeSelect: React.FC<Props> = ({ name, control }) => {
   const startTimes = getTimeIntervals();
 
-  // TODO: Make own component in own file
   const MenuItems = startTimes.map((dateString: string) => {
     const formattedTime = getFormattedTime(dateString);
 


### PR DESCRIPTION
I spent a great deal of time attempting to make this file a little bit cleaner by moving the `<MenuItem>` into a separate component (separation of concerns). Even wrote tests for that new component.

It turns out MUI doesn't like that. It wants the MenuItems rendered in the same component where the parent Select is rendered. And if you create these MenuItems as independent, "custom" components, they only get rendered when you select the Select, meaning MUI will complain with the following message:

```
MUI: You have provided an out-of-range value `2025-03-06T11:00:00.000Z` for the select (name="time") component.
```

There is a way around everything, but whatever is needed to actually make that work is far beyond the benefit of separating this particular concern. Especially since its only purpose is to get a formatted time for the Menu Item.